### PR TITLE
Remove a redundant len(x) >= 0 check.

### DIFF
--- a/commands/example_circularqueue_test.go
+++ b/commands/example_circularqueue_test.go
@@ -185,7 +185,7 @@ var cbCommands = &commands.ProtoCommands{
 	}),
 	InitialPreConditionFunc: func(state commands.State) bool {
 		s := state.(*cbState)
-		return len(s.elements) >= 0 && len(s.elements) <= s.size
+		return len(s.elements) <= s.size
 	},
 	GenCommandFunc: func(state commands.State) gopter.Gen {
 		return gen.OneGenOf(genGetCommand, genPutCommand, genSizeCommand)


### PR DESCRIPTION
len(x) is always >= 0, and this code doesn't look like it intended this to be len(x) > 0 - so let's just remove the check.